### PR TITLE
Use Placetel API v2 instead of deprecated v1

### DIFF
--- a/phonebook.rb
+++ b/phonebook.rb
@@ -17,9 +17,9 @@ class Phonebook < Sinatra::Base
     @numbers = api.get_numbers
     @numbers.map! {|x|
       {
-        fullname: x['pstn_name'],
-        formatted_number: "#{x['pstn_prefix']} #{x['pstn_numonly'].insert(-3, '-')}",
-        number: x['pstn_number']
+        fullname: x['name'],
+        formatted_number: "#{x['prefix']} #{x['numonly'].insert(-3, '-')}",
+        number: x['number']
       }
     }
 

--- a/placetel.rb
+++ b/placetel.rb
@@ -5,24 +5,45 @@ require "json"
 
 class Placetel
   attr_accessor :api_key
-  API_ENDPOINT = 'https://api.placetel.de/api'
+  API_ENDPOINT = 'https://api.placetel.de/v2'
 
   def initialize(api_key)
     @api_key = api_key
   end
 
   def get_numbers
-    json_data = post_request "#{API_ENDPOINT}/getNumbers.json", { :api_key => @api_key }
-    raise "no data received" if json_data.body.nil?
+    url = "#{API_ENDPOINT}/numbers"
+    page = 1
+    allnums = []
 
-    response = JSON.parse(json_data.body.force_encoding('UTF-8'))
+    loop do
+      page_url = url + "?filter[activated]=true&page=" + page.to_s
+      uri = URI.parse(URI.escape(page_url))
+      http = Net::HTTP.new(uri.host, uri.port)
 
-    raise response['descr'] if !response.is_a?(Array) || response.first.nil? || response.first['pstn_number'].nil?
-    response
+      if uri.scheme == 'https'
+        http.use_ssl = true
+      end
+
+      request = Net::HTTP::Get.new uri.request_uri
+      request['Authorization'] = "Bearer #{api_key}"
+
+      req = http.request(request)
+      data = JSON.parse(req.body)
+
+      if data.empty?
+        break
+      end
+
+      allnums += data
+      page += 1
+    end
+    
+    allnums
   end
 
   def initiate_call(from, to)
-    json_data = post_request "#{API_ENDPOINT}/initiateCall.json", { :api_key => @api_key,
+    json_data = post_request "#{API_ENDPOINT}/calls", { :api_key => @api_key,
                                                                     :sipuid => from,
                                                                     :target => to }
     raise "no data received" if json_data.body.nil?
@@ -44,6 +65,7 @@ class Placetel
       end
 
       request = Net::HTTP::Post.new uri.request_uri
+      request['Authorization'] = "Bearer #{api_key}"
       request.set_form_data post_params
 
       http.request(request)


### PR DESCRIPTION
This PR adds support for Placetel API v2 (https://api.placetel.de/v2/docs/) and uses the same number output behaviour as v1 (but uses pagination in the code to fetch all active numbers)

closes #3